### PR TITLE
Restricciones para evitar Usernames duplicados

### DIFF
--- a/RotomNet/src/main/java/es/trident/rotomnet/repository/UserRepository.java
+++ b/RotomNet/src/main/java/es/trident/rotomnet/repository/UserRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import es.trident.rotomnet.model.User;
 
 public interface UserRepository extends JpaRepository<User, Long>{
-	public User findByUsernameAndPwd(String username, String pwd);
+	public User findByUsernameAndPwd(String username, String pwd);	
+	public User findByUsername(String username);
 }

--- a/RotomNet/src/main/java/es/trident/rotomnet/service/UserService.java
+++ b/RotomNet/src/main/java/es/trident/rotomnet/service/UserService.java
@@ -60,16 +60,20 @@ public class UserService {
 		return repository.findByUsernameAndPwd(username, pwd);
 	}
 
-	public void modifyUser(long id, String username, String pwd, MultipartFile image) throws IOException {
-		User u = repository.findById(id).orElseThrow();
+	public void modifyUser(String username, String newUsername, String pwd, MultipartFile image) throws IOException {
+		User u = repository.findByUsername(username);
 		
 		//Modify the user if parameters are not null. 
-		if(!username.equals("")) {u.setUsername(username);}
+		if(!newUsername.equals("")) {u.setUsername(newUsername);}
 		if(!pwd.equals("")) {u.setPwd(pwd);}
 		if(!image.isEmpty()) {
 			u.setImage(true);
 			u.setImageFile(BlobProxy.generateProxy(image.getInputStream(), image.getSize()));
 		}
 		repository.save(u);
+	}
+
+	public User findUserByUsername(String username) {
+		return repository.findByUsername(username);
 	}
 }

--- a/RotomNet/src/main/resources/static/css/modify.css
+++ b/RotomNet/src/main/resources/static/css/modify.css
@@ -73,6 +73,11 @@ body{
 	left: 0;
 }
 
+.modify-form .wrong-text{
+	background:#ff7f78;
+	outline: 2px solid #ff2216;
+}
+
 .modify-form input[type=submit]{
 	border-radius:50px;
 	background-color: #7cd7e7;

--- a/RotomNet/src/main/resources/static/css/register.css
+++ b/RotomNet/src/main/resources/static/css/register.css
@@ -53,6 +53,11 @@ body {
 	left: 0;
 }
 
+.register-form .wrong-text{
+	background:#ff7f78;
+	outline: 2px solid #ff2216;
+}
+
 .register-form input[type=submit]{
 	border-radius:50px;
 	background-color: #7cd7e7;

--- a/RotomNet/src/main/resources/templates/modify.html
+++ b/RotomNet/src/main/resources/templates/modify.html
@@ -25,9 +25,17 @@
 				<td>{{user.lastLog}}</td>		
 			</tr>			
 		</table>
-		<form action="/modified_user_{{user.userId}}" method="post" class="modify-form" enctype="multipart/form-data"><br>
-				<label for="username">New Username</label><br>
-				<input type="text" id="username" name="username"><br>
+		<form action="/modified_user_{{user.username}}" method="post" class="modify-form" enctype="multipart/form-data"><br>
+				
+				{{#duplicatedUsername}}
+					<label for="username">Username already in use!</label><br>
+					<input type="text" id="newUsername" name="newUsername" class="wrong-text"><br>	
+				{{/duplicatedUsername}}
+				
+				{{^duplicatedUsername}}
+					<label for="username">New Username</label><br>
+					<input type="text" id="newUsername" name="newUsername"><br>				
+				{{/duplicatedUsername}}
 				<label for="pwd">New Password</label><br>
 				<input type="password" id="pwd" name="pwd"><br>
 				<label for= "image">New User Image</label><br>

--- a/RotomNet/src/main/resources/templates/register.html
+++ b/RotomNet/src/main/resources/templates/register.html
@@ -10,8 +10,16 @@
 		<div class = "form-container">
 			<form action="/registered" method="post" class="register-form" enctype="multipart/form-data"><br>
 				<h1>User Register</h1>
-				<label for="username">Username</label><br>
-				<input type="text" id="username" name="username"><br>
+				{{#duplicatedUsername}}
+					<label for="username">Username already in use!</label><br>
+					<input type="text" id="username" name="username" class="wrong-text"><br>
+				{{/duplicatedUsername}}
+				
+				{{^duplicatedUsername}}
+					<label for="username">Username</label><br>
+					<input type="text" id="username" name="username"><br>				
+				{{/duplicatedUsername}}
+				
 				<label for="pwd">Password</label><br>
 				<input type="password" id="pwd" name="pwd"><br>
 				<label for= "image">User Image</label><br>

--- a/RotomNet/src/main/resources/templates/users.html
+++ b/RotomNet/src/main/resources/templates/users.html
@@ -29,7 +29,7 @@
 					<td>{{daysLogged}}</td>
 					<td>{{lastLog}}</td>	
 					<td>
-						<form action="/{{userId}}_modify" class="modify-form" method="POST">
+						<form action="/modify_{{username}}" class="modify-form" method="POST">
 							<input type="submit" value="🛠">
 						</form>
 					</td>		


### PR DESCRIPTION
Modificación tanto de front-end como de back-end para evitar nombres de usuarios duplicados.

Se modifica el acceso a los usuarios, ahora a través del username en vez del id (para rutas de acceso más claras). Para la unicidad de los nombres de usuario, se genera una búsqueda por username en el repositorio de usuarios y es utilizada para registro y modificación de los usuarios.